### PR TITLE
devcontainer, fix first time build error with solargraph

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,3 +18,5 @@ RUN mkdir -p /home/$USERNAME/.vscode-server/extensions \
         && chown -R $USERNAME \
         /home/$USERNAME/.vscode-server \
         /home/$USERNAME/.vscode-server-insiders
+
+RUN su vscode -c "gem install solargraph"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,8 @@
 			"extensions": [
 				"rebornix.Ruby",
 				"sorbet.sorbet-vscode-extension",
-				"castwide.solargraph"
+				"castwide.solargraph",
+				"yzhang.markdown-all-in-one"
 			]
 		}
 	},
@@ -34,7 +35,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "gem install solargraph && bin/setup",
+	"postCreateCommand": "bin/setup",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"

--- a/README.md
+++ b/README.md
@@ -195,9 +195,7 @@ signer.key.private_to_der # => DER encoded private key
 
 This repository includes a [VSCode DevContainer](.devcontainer) configuration which automatically includes extensions for both Sorbet and Solargraph, and configures a docker image with libsodium.
 
-After checking out the repo, run `bin/setup` to install dependencies.
-
-If you are using the provided DevContainer, this happens automatically after the container image is first created. You may need to restart Solargraph for it to work correctly when first bringing up the container.
+After checking out the repo, run `bin/setup` to install dependencies. If you are using the provided DevContainer, this happens automatically after the container image is first created.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
When building (or rebuilding) a devcontainer, `solargraph` is not installed until after the container is finalized. This causes the Solargraph extension to error when loading until the `postCreateCommand` finishes.

Instead of installing `solargraph` in a `postCreateCommand`, just install it into the container!