### PR TITLE
Fix gem caching, again, for real

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,7 @@ commands:
           command : |
             #!/usr/bin/env bash
 
-            set -x
-
             TARGET_GEMFILE="./gemfiles/$PARAM_APPRAISAL.gemfile.lock"
-            echo $TARGET_GEMFILE
 
             APP_BUNDLER_VERSION=$(tail -1 $TARGET_GEMFILE | tr -d " ")
             if [ -z "$APP_BUNDLER_VERSION" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,13 +37,12 @@ commands:
             TARGET_GEMFILE="./gemfiles/$PARAM_APPRAISAL.gemfile.lock"
             echo $TARGET_GEMFILE
 
-            if test -f "$TARGET_GEMFILE"; then
-              APP_BUNDLER_VERSION=$(cat "$TARGET_GEMFILE" | tail -1 | tr -d " ")
-              if [ -z "$APP_BUNDLER_VERSION" ]; then
-                echo "Could not find bundler version from lockfile. Please use bundler-version parameter"
-              else
-                echo "Lock file detected bundler version $APP_BUNDLER_VERSION"
-              fi
+            APP_BUNDLER_VERSION=$(tail -1 $TARGET_GEMFILE | tr -d " ")
+            if [ -z "$APP_BUNDLER_VERSION" ]; then
+              echo "Could not find bundler version from lockfile."
+              exit 1
+            else
+              echo "Lock file detected bundler version $APP_BUNDLER_VERSION"
             fi
 
             if ! bundle version | grep -q $APP_BUNDLER_VERSION; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,10 +112,10 @@ jobs:
             mkdir -p ~/rspec
 
             ./tmp/cc-test-reporter before-build
-            bundle exec appraisal << parameters.appraisal >> rspec --profile 10 --order random --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec
+            bundle exec appraisal << parameters.appraisal >> rspec --profile 10 --order random
             ./tmp/cc-test-reporter format-coverage --output tmp/codeclimate.$CIRCLE_JOB.json
-      - store_test_results:
-          path: /tmp/test-results/rspec
+      # - store_test_results:
+      #     path: /tmp/test-results/rspec
       - persist_to_workspace:
           root: tmp
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,11 @@ commands:
 
             set -x
 
-            if test -f "./gemfiles/$PARAM_APPRAISAL.gemfile.lock"; then
-              APP_BUNDLER_VERSION=$(cat "./gemfiles/$PARAM_APPRAISAL.gemfile.lock" | tail -1 | tr -d " ")
+            TARGET_GEMFILE=""./gemfiles/$PARAM_APPRAISAL.gemfile.lock"
+            echo $TARGET_GEMFILE
+
+            if test -f "./gemfiles/$TARGET_GEMFILE.gemfile.lock"; then
+              APP_BUNDLER_VERSION=$(cat "./gemfiles/$TARGET_GEMFILE.gemfile.lock" | tail -1 | tr -d " ")
               if [ -z "$APP_BUNDLER_VERSION" ]; then
                 echo "Could not find bundler version from lockfile. Please use bundler-version parameter"
               else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ commands:
 
             set -x
 
-            TARGET_GEMFILE=""./gemfiles/$PARAM_APPRAISAL.gemfile.lock"
+            TARGET_GEMFILE="./gemfiles/$PARAM_APPRAISAL.gemfile.lock"
             echo $TARGET_GEMFILE
 
             if test -f "./gemfiles/$TARGET_GEMFILE.gemfile.lock"; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,14 @@ shared_env: &shared_env
   TEST_QUEUE_WORKERS: 2
   CC_TEST_REPORTER_ID: 9643f9411ff1c1d359175e948cf67205d2c35883e9dc2a6d45ffde54829abfb2
 
+all_jobs_matrix: &all_jobs_matrix
+    parameters:
+      version: ["3.0", "3.1"]
+      appraisal: [standalone, rbnacl]
+
 commands:
-  bundle-install:
-    description: "bundle install"
+  install-dependencies:
+    description: "Install gems with bundler and appraisal"
     parameters:
       appraisal:
           type: string
@@ -17,24 +22,66 @@ commands:
           type: string
           default: "3.1"
     steps:
-      # - restore_cache:
-      #     keys:
-      #       - gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
-      #       - gem-cache-v4-<< parameters.version >>-{{ arch }}
+      - restore_cache:
+          keys:
+            - gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile" }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
+            - gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile" }}
+            - gem-cache-v4-<< parameters.version >>-{{ arch }}
       - run:
-          name: "Install gems and appraisals"
+          name: "Install bundler"
           command : |
-            bundle install
+              #!/usr/bin/env bash
+
+              if test -f "./gemfiles/$APPRAISAL.gemfile.lock"; then
+                APP_BUNDLER_VERSION=$(cat "./gemfiles/$APPRAISAL.gemfile.lock" | tail -1 | tr -d " ")
+                if [ -z "$APP_BUNDLER_VERSION" ]; then
+                  echo "Could not find bundler version from lockfile. Please use bundler-version parameter"
+                else
+                  echo "Lock file detected bundler version $APP_BUNDLER_VERSION"
+                fi
+              fi
+
+              if ! bundle version | grep -q $APP_BUNDLER_VERSION; then
+                echo "Installing bundler $APP_BUNDLER_VERSION"
+                gem install bundler:$APP_BUNDLER_VERSION
+              else
+                echo "bundler $APP_BUNDLER_VERSION is already installed."
+              fi
+          environment:
+            PARAM_APPRAISAL: << parameters.appraisal >>
+      - run:
+          name: "Bundle/Appraisal Install"
+          command : |
+            #!/usr/bin/env bash
+
+            bundle config set deployment 'true'
+            bundle config set path "./vendor/bundle"
+
+            bundle install && bundle clean --force
             bundle exec appraisal install
-            gem info openssl
-            bundle exec appraisal standalone gem info openssl
-            bundle exec appraisal rbnacl gem info openssl
-      # - save_cache:
-      #     key: gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
-      #     paths:
-      #       - vendor/bundle
+          environment:
+            PARAM_APPRAISAL: << parameters.appraisal >>
+      - save_cache:
+          key: gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile" }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
+          paths:
+            - ./vendor/bundle
 
 jobs:
+  prepare-deps:
+    parameters:
+      version:
+        type: string
+        default: "3.1"
+      appraisal:
+        type: string
+        default: standalone
+    docker:
+      - image: cimg/ruby:<< parameters.version >>
+    steps:
+      - install-dependencies:
+          appraisal: << parameters.appraisal >>
+          version: << parameters.version >>
+
   specs:
     parameters:
       version:
@@ -51,15 +98,19 @@ jobs:
       - checkout
       - attach_workspace:
           at: tmp
-      - bundle-install:
+      - install-dependencies:
           appraisal: << parameters.appraisal >>
           version: << parameters.version >>
       - run:
           name: Run specs
           command: |
+            mkdir -p ~/rspec
+
             ./tmp/cc-test-reporter before-build
-            bundle exec appraisal << parameters.appraisal >> rake spec
+            bundle exec appraisal << parameters.appraisal >> rspec --profile 10 --order random --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec
             ./tmp/cc-test-reporter format-coverage --output tmp/codeclimate.$CIRCLE_JOB.json
+      - store_test_results:
+          path: /tmp/test-results/rspec
       - persist_to_workspace:
           root: tmp
           paths:
@@ -99,7 +150,7 @@ jobs:
       - image: cimg/ruby:3.1
     steps:
       - checkout
-      - bundle-install
+      - install-dependencies
       - run:
           name: "Rubocop"
           command: |
@@ -110,7 +161,7 @@ jobs:
       - image: cimg/ruby:3.1
     steps:
       - checkout
-      - bundle-install
+      - install-dependencies
       - run:
           name: "Sorbet Typecheck"
           command: |
@@ -119,36 +170,22 @@ jobs:
 workflows:
   build:
     jobs:
+      - prepare-deps:
+          matrix:
+            <<: *all_jobs_matrix
       - circleci-setup
       - typecheck:
           requires:
+            - prepare-deps
+      - specs:
+          matrix:
+            <<: *all_jobs_matrix
+          requires:
+            - prepare-deps
             - circleci-setup
       - rubocop:
           requires:
-            - typecheck
-      # - specs:
-      #     name: ruby-3.0-specs-standalone
-      #     requires:
-      #       - typecheck
-      #     version: "3.0"
-      - specs:
-          name: ruby-3.0-specs-rbnacl
-          appraisal: rbnacl
-          requires:
-            - typecheck
-          version: "3.0"
-      # - specs:
-      #     name: ruby-3.1-specs-standalone
-      #     requires:
-      #       - typecheck
-      - specs:
-          name: ruby-3.1-specs-rbnacl
-          appraisal: rbnacl
-          requires:
-            - typecheck
+            - prepare-deps
       # - circleci-upload:
       #     requires:
-      #       - ruby-3.1-specs-standalone
-      #       - ruby-3.1-specs-rbnacl
-      #       - ruby-3.0-specs-standalone
-      #       - ruby-3.0-specs-rbnacl
+      #       - specs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
             bundle config set deployment 'true'
             bundle config set path "./vendor/bundle"
 
-            bundle install && bundle clean --force
+            bundle install
             bundle exec appraisal install
           environment:
             PARAM_APPRAISAL: << parameters.appraisal >>
@@ -191,6 +191,6 @@ workflows:
       - rubocop:
           requires:
             - prepare-deps
-      # - circleci-upload:
-      #     requires:
-      #       - specs
+      - circleci-upload:
+          requires:
+            - specs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,19 +17,21 @@ commands:
           type: string
           default: "3.1"
     steps:
-      - restore_cache:
-          keys:
-            - gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
-            - gem-cache-v4-<< parameters.version >>-{{ arch }}
+      # - restore_cache:
+      #     keys:
+      #       - gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
+      #       - gem-cache-v4-<< parameters.version >>-{{ arch }}
       - run:
           name: "Install gems and appraisals"
           command : |
-            bundle install --path=vendor/bundle
-            bundle exec appraisal install --path=vendor/bundle
-      - save_cache:
-          key: gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
-          paths:
-            - vendor/bundle
+            bundle install
+            bundle exec appraisal install
+            gem list openssl
+            gem list sorbet
+      # - save_cache:
+      #     key: gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
+      #     paths:
+      #       - vendor/bundle
 
 jobs:
   specs:
@@ -123,29 +125,29 @@ workflows:
       - rubocop:
           requires:
             - typecheck
-      - specs:
-          name: ruby-3.0-specs-standalone
-          requires:
-            - typecheck
-          version: "3.0"
+      # - specs:
+      #     name: ruby-3.0-specs-standalone
+      #     requires:
+      #       - typecheck
+      #     version: "3.0"
       - specs:
           name: ruby-3.0-specs-rbnacl
           appraisal: rbnacl
           requires:
             - typecheck
           version: "3.0"
-      - specs:
-          name: ruby-3.1-specs-standalone
-          requires:
-            - typecheck
+      # - specs:
+      #     name: ruby-3.1-specs-standalone
+      #     requires:
+      #       - typecheck
       - specs:
           name: ruby-3.1-specs-rbnacl
           appraisal: rbnacl
           requires:
             - typecheck
-      - circleci-upload:
-          requires:
-            - ruby-3.1-specs-standalone
-            - ruby-3.1-specs-rbnacl
-            - ruby-3.0-specs-standalone
-            - ruby-3.0-specs-rbnacl
+      # - circleci-upload:
+      #     requires:
+      #       - ruby-3.1-specs-standalone
+      #       - ruby-3.1-specs-rbnacl
+      #       - ruby-3.0-specs-standalone
+      #       - ruby-3.0-specs-rbnacl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,22 +68,6 @@ commands:
             - ./vendor/bundle
 
 jobs:
-  prepare-deps:
-    parameters:
-      version:
-        type: string
-        default: "3.1"
-      appraisal:
-        type: string
-        default: standalone
-    docker:
-      - image: cimg/ruby:<< parameters.version >>
-    steps:
-      - checkout
-      - install-dependencies:
-          appraisal: << parameters.appraisal >>
-          version: << parameters.version >>
-
   specs:
     parameters:
       version:
@@ -172,22 +156,14 @@ jobs:
 workflows:
   build:
     jobs:
-      - prepare-deps:
-          matrix:
-            <<: *all_jobs_matrix
       - circleci-setup
-      - typecheck:
-          requires:
-            - prepare-deps
+      - typecheck
       - specs:
           matrix:
             <<: *all_jobs_matrix
           requires:
-            - prepare-deps
             - circleci-setup
-      - rubocop:
-          requires:
-            - prepare-deps
+      - rubocop
       - circleci-upload:
           requires:
             - specs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ commands:
 
             set -x
 
-            if test -f "./gemfiles/$APPRAISAL.gemfile.lock"; then
-              APP_BUNDLER_VERSION=$(cat "./gemfiles/$APPRAISAL.gemfile.lock" | tail -1 | tr -d " ")
+            if test -f "./gemfiles/$PARAM_APPRAISAL.gemfile.lock"; then
+              APP_BUNDLER_VERSION=$(cat "./gemfiles/$PARAM_APPRAISAL.gemfile.lock" | tail -1 | tr -d " ")
               if [ -z "$APP_BUNDLER_VERSION" ]; then
                 echo "Could not find bundler version from lockfile. Please use bundler-version parameter"
               else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,18 +19,17 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gem-cache-v3-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
-            - gem-cache-v3-<< parameters.version >>-{{ arch }}
+            - gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
+            - gem-cache-v4-<< parameters.version >>-{{ arch }}
       - run:
           name: "Install gems and appraisals"
           command : |
-            bundle install
-            bundle exec appraisal install
+            bundle install --path=vendor/bundle
+            bundle exec appraisal install --path=vendor/bundle
       - save_cache:
-          key: gem-cache-v3-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
+          key: gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
           paths:
-            - ~/.bundle
-            - ~/.rubygems
+            - vendor/bundle
 
 jobs:
   specs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,9 @@ commands:
           command : |
             bundle install
             bundle exec appraisal install
-            gem list openssl
-            gem list sorbet
+            gem info openssl
+            bundle exec appraisal standalone gem info openssl
+            bundle exec appraisal rbnacl gem info openssl
       # - save_cache:
       #     key: gem-cache-v4-<< parameters.version >>-{{ arch }}-{{ checksum "gemfiles/<< parameters.appraisal >>.gemfile.lock" }}
       #     paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
     docker:
       - image: cimg/ruby:<< parameters.version >>
     steps:
+      - checkout
       - install-dependencies:
           appraisal: << parameters.appraisal >>
           version: << parameters.version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,23 +30,25 @@ commands:
       - run:
           name: "Install bundler"
           command : |
-              #!/usr/bin/env bash
+            #!/usr/bin/env bash
 
-              if test -f "./gemfiles/$APPRAISAL.gemfile.lock"; then
-                APP_BUNDLER_VERSION=$(cat "./gemfiles/$APPRAISAL.gemfile.lock" | tail -1 | tr -d " ")
-                if [ -z "$APP_BUNDLER_VERSION" ]; then
-                  echo "Could not find bundler version from lockfile. Please use bundler-version parameter"
-                else
-                  echo "Lock file detected bundler version $APP_BUNDLER_VERSION"
-                fi
-              fi
+            set -x
 
-              if ! bundle version | grep -q $APP_BUNDLER_VERSION; then
-                echo "Installing bundler $APP_BUNDLER_VERSION"
-                gem install bundler:$APP_BUNDLER_VERSION
+            if test -f "./gemfiles/$APPRAISAL.gemfile.lock"; then
+              APP_BUNDLER_VERSION=$(cat "./gemfiles/$APPRAISAL.gemfile.lock" | tail -1 | tr -d " ")
+              if [ -z "$APP_BUNDLER_VERSION" ]; then
+                echo "Could not find bundler version from lockfile. Please use bundler-version parameter"
               else
-                echo "bundler $APP_BUNDLER_VERSION is already installed."
+                echo "Lock file detected bundler version $APP_BUNDLER_VERSION"
               fi
+            fi
+
+            if ! bundle version | grep -q $APP_BUNDLER_VERSION; then
+              echo "Installing bundler $APP_BUNDLER_VERSION"
+              gem install bundler:$APP_BUNDLER_VERSION
+            else
+              echo "bundler $APP_BUNDLER_VERSION is already installed."
+            fi
           environment:
             PARAM_APPRAISAL: << parameters.appraisal >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,8 @@ commands:
             TARGET_GEMFILE="./gemfiles/$PARAM_APPRAISAL.gemfile.lock"
             echo $TARGET_GEMFILE
 
-            if test -f "./gemfiles/$TARGET_GEMFILE.gemfile.lock"; then
-              APP_BUNDLER_VERSION=$(cat "./gemfiles/$TARGET_GEMFILE.gemfile.lock" | tail -1 | tr -d " ")
+            if test -f "$TARGET_GEMFILE"; then
+              APP_BUNDLER_VERSION=$(cat "$TARGET_GEMFILE" | tail -1 | tr -d " ")
               if [ -z "$APP_BUNDLER_VERSION" ]; then
                 echo "Could not find bundler version from lockfile. Please use bundler-version parameter"
               else


### PR DESCRIPTION
This time, use a --deployment configuration to install the gems to vendor/ so that I'm not guessing where they're being installed.

Also install the version of bundler that the lockfile was generated with to suppress warnings.