### PR TITLE
Handle UTF-8 decoding for payloads containing multibyte characters

### DIFF
--- a/lib/paseto/symmetric_key.rb
+++ b/lib/paseto/symmetric_key.rb
@@ -52,9 +52,12 @@ module Paseto
       t2 = protocol.hmac(pre_auth, key: ak)
       raise InvalidAuthenticator unless Util.constant_compare(t, t2)
 
-      protocol.crypt(payload: c, key: ek, nonce: n2).encode(Encoding::UTF_8)
-    rescue Encoding::UndefinedConversionError
-      raise ParseError, 'invalid payload encoding'
+      decrypted = protocol.crypt(payload: c, key: ek, nonce: n2)
+      decrypted.force_encoding('UTF-8')
+
+      raise ParseError, 'invalid payload encoding' unless decrypted.valid_encoding?
+
+      decrypted
     end
 
     sig(:final) do

--- a/spec/paseto/v4/local_spec.rb
+++ b/spec/paseto/v4/local_spec.rb
@@ -49,6 +49,18 @@ RSpec.describe 'Paseto::V4::Local', :sodium do
       end
     end
 
+    context 'when payload contains \xF0 character (emoji)' do
+      let(:message) { '{"data":"🦊"}' } # Fox emoji (contains \xF0\x9F\xA6\x8A)
+      let(:token_str) { key.encrypt(message: message).to_s }
+
+      it 'returns a UTF-8 encoded string' do
+        expect(plaintext.encoding).to eq(Encoding::UTF_8)
+      end
+
+      it { is_expected.to be_valid_encoding }
+      it { is_expected.to eq(message) }
+    end
+
     context 'when token version is not v4' do
       let(:token) { Paseto::Token.parse(token_str.sub('v4', 'v3')) }
 


### PR DESCRIPTION
References #215 submitted by @levicole earlier today

This PR modifies the original behavior of calling `.encode` on the payload and rescuing to using `.force_encoding' and then raising the `ParseError` if the decrypted payload does not have a valid encoding.


