### PR TITLE
Modify Dependabot schedule and include all directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,13 @@
 version: 2
 updates:
   - package-ecosystem: "bundler"
+    directories:
+      - "**/*"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "friday"
-      time: "23:00"
+      time: "17:00"
       timezone: "America/Los_Angeles"
     assignees:
       - "bannable"
@@ -19,7 +21,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
-      time: "23:00"
+      time: "17:00"
       timezone: "America/Los_Angeles"
     assignees:
       - "bannable"


### PR DESCRIPTION
Updated Dependabot configuration to include all directories for Bundler and GitHub Actions updates, and changed update time to 17:00.