### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,6 +11,8 @@ on:
   # random HH:MM to avoid a load spike on GitHub Actions at 00:00
   - cron: 30 4 * * *
 name: Semgrep
+permissions:
+  contents: read
 jobs:
   semgrep:
     name: semgrep/ci


### PR DESCRIPTION
Potential fix for [https://github.com/bannable/paseto/security/code-scanning/6](https://github.com/bannable/paseto/security/code-scanning/6)

Add an explicit `permissions` block to the workflow to enforce least privilege for `GITHUB_TOKEN`.  
Best fix here (without changing functionality) is to set workflow-level permissions to read-only contents, which is sufficient for `actions/checkout` and typical Semgrep scanning.

Edit **`.github/workflows/semgrep.yml`** by inserting:

```yml
permissions:
  contents: read
```

at the top level (e.g., after `name:` and before `jobs:`).  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
